### PR TITLE
fix(widget): ensure image is loaded before initializing widget

### DIFF
--- a/versatileimagefield/static/versatileimagefield/js/versatileimagefield-djangoadmin.js
+++ b/versatileimagefield/static/versatileimagefield/js/versatileimagefield-djangoadmin.js
@@ -1,1 +1,3 @@
-django.jQuery(document).ready(generateCenterpointWidget);
+django.jQuery(document).ready(function(){
+    django.jQuery('.sizedimage-preview').load(generateCenterpointWidget);
+});

--- a/versatileimagefield/static/versatileimagefield/js/versatileimagefield-jquery.js
+++ b/versatileimagefield/static/versatileimagefield/js/versatileimagefield-jquery.js
@@ -1,1 +1,3 @@
-$(document).ready(generateCenterpointWidget);
+$(document).ready(function(){
+    $('.sizedimage-preview').load(generateCenterpointWidget);
+});


### PR DESCRIPTION
`jquery.ready` doesn't take into account the loading of images.
If the images are not loaded, we get wrong image dimension
causing the PPOI widget to fail.

**Suggestion**: @WGBH, we can also get rid of two different files, if we 
put the initialisation script in [js/versatileimagefield.js](https://github.com/WGBH/django-versatileimagefield/blob/master/versatileimagefield/static/versatileimagefield/js/versatileimagefield.js)
by appropriately selecting jquery, something on the line:

```
var jQuery = window.jQuery || django.jQuery;

if (jQuery){
     jQuery(document).ready(function(){
          jQuery('.sizedimage-preview').load(generateCenterpointWidget);
     });
}
```

Thoughts? I can sent you PR if you like. But wondering are there any specific
reason to have different files.
