### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ django-versatileimagefield
 
 A drop-in replacement for django's ``ImageField`` that provides a flexible, intuitive and easily-extensible interface for creating new images from the one assigned to the field.
 
-`Click here for a quick overview <http://django-versatileimagefield.readthedocs.org/en/latest/overview.html>`_ of what it is, how it works and whether or not it's the right fit for your project.
+`Click here for a quick overview <https://django-versatileimagefield.readthedocs.io/en/latest/overview.html>`_ of what it is, how it works and whether or not it's the right fit for your project.
 
 Compatibility
 =============
@@ -43,7 +43,7 @@ Compatibility
 
 **NOTE**: The 1.4 release dropped support for Django 1.5.x & 1.6.x.
 
-- `Pillow <http://pillow.readthedocs.org/en/latest/index.html>`_ >= 2.4.0
+- `Pillow <https://pillow.readthedocs.io/en/latest/index.html>`_ >= 2.4.0
 
 - `Django REST Framework <http://www.django-rest-framework.org/>`_:
 
@@ -57,7 +57,7 @@ Compatibility
 Documentation
 =============
 
-Full documentation available at `Read the Docs <http://django-versatileimagefield.readthedocs.org/en/latest/>`_.
+Full documentation available at `Read the Docs <https://django-versatileimagefield.readthedocs.io/en/latest/>`_.
 
 Code
 ====

--- a/docs/improving_performance.rst
+++ b/docs/improving_performance.rst
@@ -27,7 +27,7 @@ This boost in performance is great but now you'll need to ensure that the images
     ... )
     >>> num_created, failed_to_create = person_img_warmer.warm()
 
-``num_created`` will be an integer of how many images were successfully created and ``failed_to_create`` will be a list of paths to images (on the field's storage class) that could not be created (due to a `PIL/Pillow <https://pillow.readthedocs.org/>`_ error, for example).
+``num_created`` will be an integer of how many images were successfully created and ``failed_to_create`` will be a list of paths to images (on the field's storage class) that could not be created (due to a `PIL/Pillow <https://pillow.readthedocs.io/>`_ error, for example).
 
 This technique is useful if you've recently converted your project's ``models.ImageField`` fields to use ``VersatileImageField`` or if you want to 'pre warm' images as part of a `Fabric <http://www.fabfile.org/>`_ script.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,7 @@ Compatibility
 
 .. note:: The 1.4 release dropped support for Django 1.5.x & 1.6.x.
 
-- `Pillow <http://pillow.readthedocs.org/en/latest/index.html>`_ >= 2.4.0
+- `Pillow <https://pillow.readthedocs.io/en/latest/index.html>`_ >= 2.4.0
 
 - `Django REST Framework <http://www.django-rest-framework.org/>`_:
 
@@ -167,7 +167,7 @@ Release Notes
 ^^^
 - Squashed a bug that raised a ``ValueError`` in the admin when editing a model instance with a ``VersatileImageField`` that specified ``ppoi_field``, ``width_field`` and ``height_field``.
 - Admin 'click' widget now works in Firefox.
-- ``django-versatileimagefield`` is now available for installation via `wheel <http://wheel.readthedocs.org/en/latest/>`_.
+- ``django-versatileimagefield`` is now available for installation via `wheel <https://wheel.readthedocs.io/en/latest/>`_.
 
 0.5.4
 ^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,7 +27,7 @@ Dependencies
 -  ``Pillow`` >= 2.4.x
 
 ``django-versatileimagefield`` depends on the excellent
-`Pillow <http://pillow.readthedocs.org>`__ fork of ``PIL``. If you
+`Pillow <https://pillow.readthedocs.io>`__ fork of ``PIL``. If you
 already have PIL installed, it is recommended you uninstall it prior to
 installing ``django-versatileimagefield``:
 
@@ -71,7 +71,7 @@ A dictionary that allows you to fine-tune how ``django-versatileimagefield`` wor
         # provided, the 'default' cache will be used instead.
         'cache_name': 'versatileimagefield_cache',
         # The save quality of modified JPEG images. More info here:
-        # http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#jpeg
+        # https://pillow.readthedocs.io/en/latest/handbook/image-file-formats.html#jpeg
         # Defaults to 70
         'jpeg_resize_quality': 70,
         # The name of the top-level folder within storage classes to save all

--- a/docs/model_integration.rst
+++ b/docs/model_integration.rst
@@ -261,5 +261,5 @@ Where ``OnStoragePlaceholderImage`` saves images to
 Placeholder images defined by ``OnStoragePlaceholderImage`` will be saved into the placeholder directory (defaults to ``'__placeholder__'`` :ref:`docs <versatileimagefield-settings>`) within the same folder heirarchy as their original storage class. The placeholder image used in the example above would be saved to ``'__placeholder__/image/placeholder.gif``.
 
 .. _django.db.models.ImageField: https://docs.djangoproject.com/en/dev/ref/models/fields/#imagefield
-.. _south: http://south.readthedocs.org/en/latest/index.html
+.. _south: https://south.readthedocs.io/en/latest/index.html
 .. _default_storage: https://docs.djangoproject.com/en/dev/topics/files/#file-storage

--- a/docs/specifying_ppoi.rst
+++ b/docs/specifying_ppoi.rst
@@ -9,7 +9,7 @@ initial inspiration for ``django-versatileimagefield`` came as a result
 of tackling this very problem.
 
 The ``crop`` Sizer's core functionality (located in the ``versatileimagefield.versatileimagefield.CroppedImage.crop_on_centerpoint`` method) was inspired by PIL's
-`ImageOps.fit <http://pillow.readthedocs.org/en/latest/reference/ImageOps.html#PIL.ImageOps.fit>`__
+`ImageOps.fit <https://pillow.readthedocs.io/en/latest/reference/ImageOps.html#PIL.ImageOps.fit>`__
 function (by `Kevin Cazabon <http://www.cazabon.com/>`__) which takes an optional
 keyword argument, ``centering``, that expects a 2-tuple comprised of
 floats which are greater than or equal to 0 and less than or equal to 1. These two values
@@ -84,7 +84,7 @@ model and then include the name of that field in the
 ``VersatileImageField``'s ``ppoi_field`` keyword argument. That's it!
 
 .. note:: ``PPOIField`` is fully-compatible with
-    `south <http://south.readthedocs.org/en/latest/index.html>`_ so
+    `south <https://south.readthedocs.io/en/latest/index.html>`_ so
     migrate to your heart's content!
 
 How PPOI is Stored in the Database

--- a/tests/post_processor/test_settings.py
+++ b/tests/post_processor/test_settings.py
@@ -11,7 +11,7 @@ VERSATILEIMAGEFIELD_SETTINGS = {
     # provided, the 'default' cache will be used instead.
     'cache_name': 'versatileimagefield_cache',
     # The save quality of modified JPEG images. More info here:
-    # http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#jpeg
+    # https://pillow.readthedocs.io/en/latest/handbook/image-file-formats.html#jpeg
     # Defaults to 70
     'jpeg_resize_quality': 70,
     # A path on disc to an image that will be used as a 'placeholder'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,7 +10,7 @@ VERSATILEIMAGEFIELD_SETTINGS = {
     # provided, the 'default' cache will be used instead.
     'cache_name': 'versatileimagefield_cache',
     # The save quality of modified JPEG images. More info here:
-    # http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#jpeg
+    # https://pillow.readthedocs.io/en/latest/handbook/image-file-formats.html#jpeg
     # Defaults to 70
     'jpeg_resize_quality': 70,
     # A path on disc to an image that will be used as a 'placeholder'

--- a/versatileimagefield/settings.py
+++ b/versatileimagefield/settings.py
@@ -28,7 +28,7 @@ VERSATILEIMAGEFIELD_SETTINGS = {
     # provided, the 'default' cache will be used.
     'cache_name': VERSATILEIMAGEFIELD_CACHE_NAME,
     # The save quality of modified JPEG images. More info here:
-    # http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#jpeg
+    # https://pillow.readthedocs.io/en/latest/handbook/image-file-formats.html#jpeg
     # Defaults to 70
     'jpeg_resize_quality': QUAL,
     # The name of the top-level folder within your storage to save all


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.