### PR TITLE
Update Pillow to latest stable 3.4.2 release

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,7 +51,7 @@ Compatibility
 
 .. note:: The 1.4 release dropped support for Django 1.5.x & 1.6.x.
 
-- `Pillow <https://pillow.readthedocs.io/en/latest/index.html>`_ >=2.4.0,<=3.3.3
+- `Pillow <https://pillow.readthedocs.io/en/latest/index.html>`_ >=2.4.0,<=3.4.2
 
 - `Django REST Framework <http://www.django-rest-framework.org/>`_:
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
                 "creating new images from the one assigned to the field.",
     long_description=open('README.rst').read(),
     zip_safe=False,
-    install_requires=['Pillow>=2.4.0,<=3.3.3'],
+    install_requires=['Pillow>=2.4.0,<=3.4.2'],
     package_data={
         'versatileimagefield': [
             'static/versatileimagefield/css/*.css',

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -1,5 +1,5 @@
 Django==1.9.6
-Pillow==3.2
+Pillow==3.4.2
 Sphinx==1.2.3
 coverage==3.7.1
 coveralls==0.5


### PR DESCRIPTION
Pillow's latest stable release with seemingly non-breaking API changes is 3.4.2, which would allow for Windows and Mac support with a wide range of prebuilt Pillow binaries available from PyPI.

Documentation already refers to 3.4.2 compatibility in many places, but the setup.py and some remaining references are to older versions.

This patchset changes remaining references to 3.4.2 compatible ones and updates the library installation and test requirements to the latest stable release.

Closes #78 