### PR TITLE
Fix typo with extra bracket

### DIFF
--- a/docs/writing_custom_sizers_and_filters.rst
+++ b/docs/writing_custom_sizers_and_filters.rst
@@ -321,7 +321,7 @@ is registered (see the highlighted lines in the following code block for the rel
 
     # Registering the ThumbnailSizer to be available on VersatileImageField
     # via the `thumbnail` attribute
-    versatileimagefield_registry.register_sizer('thumbnail', ThumbnailImage)]
+    versatileimagefield_registry.register_sizer('thumbnail', ThumbnailImage)
 
 All Sizers are registered via the ``versatileimagefield_registry.register_sizer`` method. The first
 argument is the attribute you want to make the Sizer available at and


### PR DESCRIPTION
Minor typo that I noticed.

Also in `docs/writing_custom_sizers_and_filters.rst`, I noticed it said to use `StringIO` for `process_image` but in python 3 it seemed like the case was that I should use `BytesIO`. Should we update the docs to reflect this for python 3?