### PR TITLE
Still show the widget even if thumbnailing fails/crashes

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1000,7 +1000,7 @@ class VersatileImageFieldTestCase(VersatileImageFieldBaseTestCase):
         )
 
         instance.image.create_on_demand = True
-        with self.assertRaises((IOError, OSError)):
+        with self.assertRaises((AttributeError, IOError, OSError)):
             instance.image.thumbnail['200x200']
 
         admin_url = reverse('admin:tests_versatileimagetestmodel_change', args=(instance.pk,))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1003,6 +1003,17 @@ class VersatileImageFieldTestCase(VersatileImageFieldBaseTestCase):
         with self.assertRaises((IOError, OSError)):
             instance.image.thumbnail['200x200']
 
-        # admin_url = reverse('admin:tests_versatileimagetestmodel_change', args=(instance.pk,))
-        # response = self.client.get(admin_url)
-        # print(response)
+        admin_url = reverse('admin:tests_versatileimagetestmodel_change', args=(instance.pk,))
+        response = self.client.get(admin_url)
+        response.render()
+        self.assertContains(
+            response,
+            """
+            <div class="sizedimage-mod initial">
+              <label class="versatileimagefield-label">Currently</label>
+              <a href="/media/stuff.png">stuff.png</a>
+            </div>
+            """,
+            html=True)
+
+        instance.image.delete()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1008,12 +1008,11 @@ class VersatileImageFieldTestCase(VersatileImageFieldBaseTestCase):
         response.render()
         self.assertContains(
             response,
-            """
-            <div class="sizedimage-mod initial">
-              <label class="versatileimagefield-label">Currently</label>
-              <a href="/media/stuff.png">stuff.png</a>
-            </div>
-            """,
-            html=True)
+            '<label class="versatileimagefield-label">Currently</label>',
+        )
+        self.assertContains(
+            response,
+            '<a href="/media/stuff',
+        )
 
-        instance.image.delete()
+        instance.image.delete(save=False)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,6 +12,7 @@ from django.contrib.auth.models import User
 from django.core import serializers
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse
 from django.template.loader import get_template
@@ -978,3 +979,30 @@ class VersatileImageFieldTestCase(VersatileImageFieldBaseTestCase):
         image, save_kwargs = processor.preprocess_JPEG(image_info[0])
 
         self.assertEqual(image.mode, 'RGB')
+
+    def test_corrupt_file(self):
+        with open(
+            os.path.join(
+                os.path.dirname(upath(__file__)),
+                "test.png"
+            ),
+            'rb'
+        ) as fp:
+            # Anything which cannot be resized or thumbnailed, but checks out
+            # when only looking at basic header data
+            content = fp.read()[:100]
+
+        instance = VersatileImageTestModel()
+        instance.image.save(
+            'stuff.png',
+            ContentFile(content),
+            save=True,
+        )
+
+        instance.image.create_on_demand = True
+        with self.assertRaises((IOError, OSError)):
+            instance.image.thumbnail['200x200']
+
+        # admin_url = reverse('admin:tests_versatileimagetestmodel_change', args=(instance.pk,))
+        # response = self.client.get(admin_url)
+        # print(response)

--- a/versatileimagefield/fields.py
+++ b/versatileimagefield/fields.py
@@ -221,4 +221,5 @@ class PPOIField(CharField):
         value = self._get_val_from_obj(obj)
         return self.get_prep_value(value)
 
+
 __all__ = ['VersatileImageField']

--- a/versatileimagefield/registry.py
+++ b/versatileimagefield/registry.py
@@ -179,6 +179,7 @@ class VersatileImageFieldRegistry(object):
         else:
             del self._filter_registry[attr_name]
 
+
 versatileimagefield_registry = VersatileImageFieldRegistry()
 
 

--- a/versatileimagefield/templates/versatileimagefield/forms/widgets/versatile_image.html
+++ b/versatileimagefield/templates/versatileimagefield/forms/widgets/versatile_image.html
@@ -20,7 +20,7 @@
          data-image_preview_id="{{ widget.image_preview_id }}">
       <div class="ppoi-point" id="{{ widget.ppoi_id }}"></div>
     </div>
-    {% if widget.value %}
+    {% if widget.value and widget.sized_url %}
     <div class="image-wrap inner">
       <img src="{{ widget.sized_url }}" id="{{ widget.image_preview_id }}"
            data-hidden_field_id="{{ widget.hidden_field_id }}"

--- a/versatileimagefield/templates/versatileimagefield/forms/widgets/versatile_image_bootstrap.html
+++ b/versatileimagefield/templates/versatileimagefield/forms/widgets/versatile_image_bootstrap.html
@@ -20,7 +20,7 @@
          data-image_preview_id="{{ widget.image_preview_id }}">
       <div class="ppoi-point" id="{{ widget.ppoi_id }}"></div>
     </div>
-    {% if widget.value %}
+    {% if widget.value and widget.sized_url %}
     <div class="image-wrap inner">
       <img src="{{ widget.sized_url }}" id="{{ widget.image_preview_id }}"
            data-hidden_field_id="{{ widget.hidden_field_id }}"

--- a/versatileimagefield/validators.py
+++ b/versatileimagefield/validators.py
@@ -75,4 +75,5 @@ def validate_ppoi(value, return_converted_tuple=False):
         if to_return and return_converted_tuple is True:
             return to_return
 
+
 __all__ = ['validate_ppoi_tuple', 'validate_ppoi']

--- a/versatileimagefield/versatileimagefield.py
+++ b/versatileimagefield/versatileimagefield.py
@@ -197,6 +197,7 @@ class InvertImage(FilteredImage):
         )
         return imagefile
 
+
 versatileimagefield_registry.register_sizer('crop', CroppedImage)
 versatileimagefield_registry.register_sizer('thumbnail', ThumbnailImage)
 versatileimagefield_registry.register_filter('invert', InvertImage)

--- a/versatileimagefield/widgets.py
+++ b/versatileimagefield/widgets.py
@@ -52,6 +52,15 @@ class ClearableFileInputWithImagePreview(ClearableFileInput):
             context = self.get_context(name, value, attrs)
             return render_to_string(self.template_name, context)
 
+    def get_sized_url(self, value):
+        """Do not fail completely on invalid images"""
+        try:
+            # Ensuring admin preview thumbnails are created and available
+            value.create_on_demand = True
+            return value.thumbnail['300x300']
+        except (IOError, OSError):
+            return None
+
     def get_context(self, name, value, attrs):
         """Get the context to render this widget with."""
         if self.has_template_widget_rendering:
@@ -84,13 +93,11 @@ class ClearableFileInputWithImagePreview(ClearableFileInput):
         })
 
         if value and hasattr(value, "url"):
-            # Ensuring admin preview thumbnails are created and available
-            value.create_on_demand = True
             context['widget'].update({
                 'hidden_field_id': self.get_hidden_field_id(name),
                 'point_stage_id': self.get_point_stage_id(name),
                 'ppoi_id': self.get_ppoi_id(name),
-                'sized_url': value.thumbnail['300x300'],
+                'sized_url': self.get_sized_url(value),
                 'image_preview_id': self.image_preview_id(name),
             })
 

--- a/versatileimagefield/widgets.py
+++ b/versatileimagefield/widgets.py
@@ -58,7 +58,9 @@ class ClearableFileInputWithImagePreview(ClearableFileInput):
             # Ensuring admin preview thumbnails are created and available
             value.create_on_demand = True
             return value.thumbnail['300x300']
-        except (IOError, OSError):
+        except Exception:
+            # Do not be overly specific with exceptions; we'd rather show no
+            # thumbnail than crash when showing the widget.
             return None
 
     def get_context(self, name, value, attrs):


### PR DESCRIPTION
When an image is not uploaded completely the sizers crash. This has been discussed several times before (resp. crashes when the image file does not exist etc.), and fixes have been rejected. (I do not fully agree with the resolution, but that's not the point of this pull request.)

However, it should still be possible to remove or replace these files again. The current implementation which calls `.thumbnail['300x300']` prevents this by causing the whole fieldset containing the versatile image field admin widget to disappear.