### PR TITLE
New setting VERSATILEIMAGEFIELD_CRASH_ON_BAD

### DIFF
--- a/versatileimagefield/datastructures/sizedimage.py
+++ b/versatileimagefield/datastructures/sizedimage.py
@@ -142,12 +142,20 @@ class SizedImage(ProcessedImage, dict):
                     if resized_storage_path and not self.storage.exists(
                         resized_storage_path
                     ):
-                        self.create_resized_image(
-                            path_to_image=self.path_to_image,
-                            save_path_on_storage=resized_storage_path,
-                            width=width,
-                            height=height
-                        )
+                        try:
+                            self.create_resized_image(
+                                path_to_image=self.path_to_image,
+                                save_path_on_storage=resized_storage_path,
+                                width=width,
+                                height=height
+                            )
+                        except (OSError, IOError, EOFError) as e:
+                            # Do we really want to crash on bad imges? 
+                            if getattr(settings, 'VERSATILEIMAGEFIELD_CRASH_ON_BAD', True):
+                                raise
+                            # Otherwise just throw a warning
+                            warnings.warn('Unable to resize image %s' % self.path_to_image)
+                            return
 
                         resized_url = self.storage.url(resized_storage_path)
 

--- a/versatileimagefield/datastructures/sizedimage.py
+++ b/versatileimagefield/datastructures/sizedimage.py
@@ -1,6 +1,8 @@
 """Datastructures for sizing images."""
 from __future__ import unicode_literals
 
+import warnings
+
 from django.conf import settings
 from django.utils.encoding import python_2_unicode_compatible
 from ..settings import (

--- a/versatileimagefield/datastructures/sizedimage.py
+++ b/versatileimagefield/datastructures/sizedimage.py
@@ -151,8 +151,8 @@ class SizedImage(ProcessedImage, dict):
                                 width=width,
                                 height=height
                             )
-                        except (OSError, IOError, EOFError) as e:
-                            # Do we really want to crash on bad imges? 
+                        except (OSError, IOError, EOFError):
+                            # Do we really want to crash on bad imges?
                             if getattr(settings, 'VERSATILEIMAGEFIELD_CRASH_ON_BAD', True):
                                 raise
                             # Otherwise just throw a warning

--- a/versatileimagefield/utils.py
+++ b/versatileimagefield/utils.py
@@ -213,7 +213,9 @@ def get_url_from_image_key(image_instance, image_key):
         size_key = None
     img_url = reduce(getattr, img_key_split, image_instance)
     if size_key:
-        img_url = img_url[size_key].url
+        img_url_sized = img_url[size_key]
+        if img_url_sized:
+            img_url = img_url_sized.url
     return img_url
 
 


### PR DESCRIPTION
In a large production deployment, we found some image files were crashing PIL. We didn't like that, and neither did our users.

New setting, VERSATILEIMAGEFIELD_CRASH_ON_BAD, default True to match current behaviour.

Set it to False, and it will (won't?) do what it says on the tin. Crises (plural) averted. It'll still raise a warning though, in case you're interested. 