### PR TITLE
Update BytesIO size instead of None when initialize InMemoryUploadedFile

### DIFF
--- a/versatileimagefield/datastructures/base.py
+++ b/versatileimagefield/datastructures/base.py
@@ -165,7 +165,7 @@ class ProcessedImage(object):
             None,
             'foo.%s' % file_ext,
             mime_type,
-            None,
+            imagefile.getbuffer().nbytes,
             None
         )
         file_to_save.seek(0)

--- a/versatileimagefield/datastructures/base.py
+++ b/versatileimagefield/datastructures/base.py
@@ -165,7 +165,7 @@ class ProcessedImage(object):
             None,
             'foo.%s' % file_ext,
             mime_type,
-            imagefile.getbuffer().nbytes,
+            imagefile.tell(),
             None
         )
         file_to_save.seek(0)


### PR DESCRIPTION
By default, ```InMemoryUploadedFile```'s size is None and calling ```len``` function will raise ```TypeError: 'NoneType' object cannot be interpreted as an integer``` error.

This PR assigns actual size for ```InMemoryUploadedFile``` and then ```len``` can be called in later postprocess such as uploading to s3 or other remote storage.