### PR TITLE
Update dependencies for Python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,10 @@ matrix:
       env: DJANGO_VERSION=1.11.9 REST_FRAMEWORK_VERSION=3.7.7
     - python: "3.6"
       env: DJANGO_VERSION=2.0.1 REST_FRAMEWORK_VERSION=3.7.7
+    - python: "3.7"
+      dist: xenial
+      sudo: required
+      env: DJANGO_VERSION=2.0.1 REST_FRAMEWORK_VERSION=3.7.7
 before_install:
   - export DJANGO_SETTINGS_MODULE=tests.test_settings
 # Tell it the things it will need to install when it boots

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Compatibility
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
 
 **NOTE**: The 1.2 release dropped support for Python 3.3.x.
 
@@ -40,7 +41,10 @@ Compatibility
   - 1.11.x
   - 2.0.x
 
+**NOTE**: Python 3.7 does not have support for Django 1.x.
+
 **NOTE**: The 1.4 release dropped support for Django 1.5.x & 1.6.x.
+
 **NOTE**: The 1.7 release dropped support for Django 1.7.x.
 
 - `Pillow <https://pillow.readthedocs.io/en/latest/index.html>`_ >= 2.4.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
                 "creating new images from the one assigned to the field.",
     long_description=open('README.rst').read(),
     zip_safe=False,
-    install_requires=['Pillow>=2.4.0,<=5.0.0'],
+    install_requires=['Pillow>=2.4.0,<6.0.0'],
     include_package_data=True,
     keywords=[
         'django',


### PR DESCRIPTION
This PR edits the Pillow requirement version to include the minor revisions, which includes the 5.2.0 that officially adds the python 3.7 support (important for Windows users as the 5.2.0 adds the Python 3.7 wheel).

The travis configuration was updated as well, but only to test on django 2.0 as Python 3.7 is [not officially supported for 1.x](https://docs.djangoproject.com/en/2.0/faq/install/#what-python-version-can-i-use-with-django).