### PR TITLE
Remove deprecation warning on Django 2.0 and newer

### DIFF
--- a/versatileimagefield/fields.py
+++ b/versatileimagefield/fields.py
@@ -204,7 +204,7 @@ class PPOIField(CharField):
         super(PPOIField, self).contribute_to_class(cls, name, **kwargs)
         setattr(cls, self.name, Creator(self))
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, *args, **kwargs):
         return self.to_python(value)
 
     def to_python(self, value):


### PR DESCRIPTION
Latest Pytest throws deprecation warnings into the console, this PR gets rid of one of them.
`context` keyword argument of `from_db_value` was dropped in Django 2.0 and will be deprecated in Django 3.0