### PR TITLE
prevent getting warning from mypy and Pycharm

### DIFF
--- a/versatileimagefield/fields.py
+++ b/versatileimagefield/fields.py
@@ -229,4 +229,4 @@ class PPOIField(CharField):
         return self.get_prep_value(value)
 
 
-__all__ = ['VersatileImageField']
+__all__ = ['VersatileImageField', 'PPOIField']


### PR DESCRIPTION
prevent getting warning from mypy and Pycharm if `versatileimagefield.fields.PPOIField` is used