### PR TITLE
Add a default_thumbnail_size option in the VERSATILEIMAGEFIELD_SETTINGS as a dictionary with model name as keys

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -108,7 +108,9 @@ A dictionary that allows you to fine-tune how ``django-versatileimagefield`` wor
         'image_key_post_processor': None,
         # Whether to create progressive JPEGs. Read more about progressive JPEGs
         # here: https://optimus.io/support/progressive-jpeg/
-        'progressive_jpeg': False
+        'progressive_jpeg': False,
+        # The default size of the thumbnail image in an admin page.
+        'default_thumbnail_size': '300x300'
     }
 
 .. _placehold-it:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -120,6 +120,11 @@ A dictionary that allows you to fine-tune how ``django-versatileimagefield`` wor
 
 A boolean that signifies whether optional (``blank=True``) ``VersatileImageField`` fields that do not  :ref:`specify a placeholder image <defining-placeholder-images>` should return `placehold.it <http://placehold.it/>`__ URLs.
 
+``VERSATILEIMAGEFIELD_PLACEHOLDIT_SUFFIX``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A string that gets added to the URL generated for placehold.it
+
 .. _rendition-key-sets:
 
 ``VERSATILEIMAGEFIELD_RENDITION_KEY_SETS``

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,5 +30,7 @@ VERSATILEIMAGEFIELD_SETTINGS = {
     # Whether or not to create new images on-the-fly. Set this to `False` for
     # speedy performance but don't forget to 'pre-warm' to ensure they're
     # created and available at the appropriate URL.
-    'create_images_on_demand': False
+    'create_images_on_demand': False,
+    # The default size of the thumbnail image in an admin page.
+    'default_thumbnail_size': '300x300'
 }

--- a/versatileimagefield/datastructures/sizedimage.py
+++ b/versatileimagefield/datastructures/sizedimage.py
@@ -114,9 +114,10 @@ class SizedImage(ProcessedImage, dict):
             )
 
         if not self.path_to_image and getattr(
-            settings, 'VERSATILEIMAGEFIELD_USE_PLACEHOLDIT', False
+            settings, 'VERSATILEIMAGEFIELD_PLACEHOLDIT_SUFFIX', False
         ):
-            resized_url = "http://placehold.it/%dx%d" % (width, height)
+            resized_url = "http://placehold.it/%dx%d" % (width, height) \
+                          + settings.VERSATILEIMAGEFIELD_PLACEHOLDIT_SUFFIX
             resized_storage_path = resized_url
         else:
             resized_storage_path = get_resized_path(

--- a/versatileimagefield/settings.py
+++ b/versatileimagefield/settings.py
@@ -18,7 +18,9 @@ VERSATILEIMAGEFIELD_SIZED_DIRNAME = '__sized__'
 VERSATILEIMAGEFIELD_FILTERED_DIRNAME = '__filtered__'
 VERSATILEIMAGEFIELD_PLACEHOLDER_DIRNAME = '__placeholder__'
 VERSATILEIMAGEFIELD_CREATE_ON_DEMAND = True
-VERSATILEIMAGEFIELD_THUMBNAIL_SIZE = '300x300'
+VERSATILEIMAGEFIELD_THUMBNAIL_SIZE = {
+    # 'instance._meta.model_name': 'widthxheight'
+} # Defaults to full-sized image
 
 VERSATILEIMAGEFIELD_SETTINGS = {
     # The amount of time, in seconds, that references to created images

--- a/versatileimagefield/settings.py
+++ b/versatileimagefield/settings.py
@@ -18,6 +18,7 @@ VERSATILEIMAGEFIELD_SIZED_DIRNAME = '__sized__'
 VERSATILEIMAGEFIELD_FILTERED_DIRNAME = '__filtered__'
 VERSATILEIMAGEFIELD_PLACEHOLDER_DIRNAME = '__placeholder__'
 VERSATILEIMAGEFIELD_CREATE_ON_DEMAND = True
+VERSATILEIMAGEFIELD_THUMBNAIL_SIZE = '300x300'
 
 VERSATILEIMAGEFIELD_SETTINGS = {
     # The amount of time, in seconds, that references to created images
@@ -59,7 +60,9 @@ VERSATILEIMAGEFIELD_SETTINGS = {
     'image_key_post_processor': None,
     # Whether to create progressive JPEGs. Read more about progressive JPEGs
     # here: https://optimus.io/support/progressive-jpeg/
-    'progressive_jpeg': False
+    'progressive_jpeg': False,
+    # The default size of the thumbnail image in an admin page.
+    'default_thumbnail_size': VERSATILEIMAGEFIELD_THUMBNAIL_SIZE
 }
 
 USER_DEFINED = getattr(

--- a/versatileimagefield/widgets.py
+++ b/versatileimagefield/widgets.py
@@ -58,8 +58,13 @@ class ClearableFileInputWithImagePreview(ClearableFileInput):
         try:
             # Ensuring admin preview thumbnails are created and available
             value.create_on_demand = True
-            thumbnail_size = VERSATILEIMAGEFIELD_SETTINGS['default_thumbnail_size']
-            return value.thumbnail[thumbnail_size]
+            thumbnail_size = VERSATILEIMAGEFIELD_SETTINGS['default_thumbnail_size'].get(
+                value.instance._meta.model_name)
+            if thumbnail_size:
+                return value.thumbnail[thumbnail_size]
+            else:
+                value.name = value.url
+                return value
         except Exception:
             # Do not be overly specific with exceptions; we'd rather show no
             # thumbnail than crash when showing the widget.

--- a/versatileimagefield/widgets.py
+++ b/versatileimagefield/widgets.py
@@ -4,6 +4,7 @@ import django
 from django.forms.widgets import ClearableFileInput, HiddenInput, MultiWidget, Select
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
+from .settings import VERSATILEIMAGEFIELD_SETTINGS
 
 CENTERPOINT_CHOICES = (
     ('0.0x0.0', 'Top Left'),
@@ -57,7 +58,8 @@ class ClearableFileInputWithImagePreview(ClearableFileInput):
         try:
             # Ensuring admin preview thumbnails are created and available
             value.create_on_demand = True
-            return value.thumbnail['300x300']
+            thumbnail_size = VERSATILEIMAGEFIELD_SETTINGS['default_thumbnail_size']
+            return value.thumbnail[thumbnail_size]
         except Exception:
             # Do not be overly specific with exceptions; we'd rather show no
             # thumbnail than crash when showing the widget.


### PR DESCRIPTION
Added change on top of
https://github.com/respondcreate/django-versatileimagefield/pull/139