### PR TITLE
Allow Pillow version 6.x in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
                 "creating new images from the one assigned to the field.",
     long_description=open('README.rst').read(),
     zip_safe=False,
-    install_requires=['Pillow>=2.4.0,<6.0.0'],
+    install_requires=['Pillow>=2.4.0,<7.0.0'],
     include_package_data=True,
     keywords=[
         'django',


### PR DESCRIPTION
Although changelog[1] says v1.10 added support for Pillow 6.x, setup.py still install Pillow <6. This commit fixes this. 

[1] https://github.com/respondcreate/django-versatileimagefield/blob/master/docs/index.rst#110