### PR TITLE
Add webp to mime type identifiers

### DIFF
--- a/versatileimagefield/utils.py
+++ b/versatileimagefield/utils.py
@@ -33,6 +33,7 @@ MIME_TYPE_TO_PIL_IDENTIFIER = {
     'image/tiff': 'TIFF',
     'image/x-xbitmap': 'XBM',
     'image/x-xpm': 'XPM',
+    'image/webp': 'WEBP',
 }
 
 


### PR DESCRIPTION
As per [Pillow docs](https://pillow.readthedocs.io/en/5.1.x/handbook/image-file-formats.html#webp), support for webp is available,  but it's missing from supported mime type list.