### PR TITLE
Remove use of deprecated function.

### DIFF
--- a/versatileimagefield/fields.py
+++ b/versatileimagefield/fields.py
@@ -5,7 +5,7 @@ from django import VERSION as DJANGO_VERSION
 from django.contrib.admin.widgets import AdminFileWidget
 from django.db.models.fields import CharField
 from django.db.models.fields.files import ImageField
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .files import VersatileImageFieldFile, VersatileImageFileDescriptor
 from .forms import SizedImageCenterpointClickDjangoAdminField


### PR DESCRIPTION
`django.utils.translation.ugettext_lazy()` is deprecated in favor of` django.utils.translation.gettext_lazy()` and will be removed in Django 4.0