### PR TITLE
docs: Fix simple typo, existant -> existent

### DIFF
--- a/docs/model_integration.rst
+++ b/docs/model_integration.rst
@@ -88,7 +88,7 @@ And here's that same model using ``VersatileImageField`` instead (see highlighte
 Specifying Placeholder Images
 -----------------------------
 
-For ``VersatileImageField`` fields that are set to ``blank=True`` you can optionally specify a placeholder image to be used when its sizers and filters are accessed (like a generic silouette for a non-existant user profile image, for instance).
+For ``VersatileImageField`` fields that are set to ``blank=True`` you can optionally specify a placeholder image to be used when its sizers and filters are accessed (like a generic silouette for a non-existent user profile image, for instance).
 
 You have two options for specifying placeholder images:
 

--- a/tests/post_processor/test_settings.py
+++ b/tests/post_processor/test_settings.py
@@ -15,7 +15,7 @@ VERSATILEIMAGEFIELD_SETTINGS = {
     # Defaults to 70
     'jpeg_resize_quality': 70,
     # A path on disc to an image that will be used as a 'placeholder'
-    # for non-existant images.
+    # for non-existent images.
     # If 'global_placeholder_image' is unset, the excellent, free-to-use
     # http://placehold.it service will be used instead.
     'global_placeholder_image': os.path.join(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,7 +14,7 @@ VERSATILEIMAGEFIELD_SETTINGS = {
     # Defaults to 70
     'jpeg_resize_quality': 70,
     # A path on disc to an image that will be used as a 'placeholder'
-    # for non-existant images.
+    # for non-existent images.
     # If 'global_placeholder_image' is unset, the excellent, free-to-use
     # http://placehold.it service will be used instead.
     'global_placeholder_image': os.path.join(


### PR DESCRIPTION
There is a small typo in docs/model_integration.rst, tests/post_processor/test_settings.py, tests/test_settings.py.

Should read `existent` rather than `existant`.

