### PR TITLE
Add Tox and Github Actions CI support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,80 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: [python3.9, python3.8]
+        django-version: [django3.2, django3.1, django3.0, django2.2]
+        drf-version: [drf3.12, drf3.11, drf3.10, drf3.09]
+        exclude:
+         - os: ubuntu-20.04
+           django-version: django3.2
+           drf-version: drf3.10
+         - os: ubuntu-20.04
+           django-version: django3.1
+           drf-version: drf3.10
+         - os: ubuntu-20.04
+           django-version: django3.2
+           drf-version: drf3.09
+         - os: ubuntu-20.04
+           django-version: django3.1
+           drf-version: drf3.09
+         - os: ubuntu-20.04
+           django-version: django3.0
+           drf-version: drf3.09
+    name: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.django-version }}-${{ matrix.drf-version }}
+    steps:
+    - name: "Set job environments"
+      run: |
+          matrix_python="${{ matrix.python-version }}"
+          matrix_django="${{ matrix.django-version }}"
+          matrix_drf="${{ matrix.drf-version }}"
+          python_v="${matrix_python//[a-zA-Z]}"
+          django_v="${matrix_django//[a-zA-Z\.]}"
+          drf_v="${matrix_drf//[a-zA-Z\.]}"
+          tox_env_name="py${python_v}-django${django_v}-drf${drf_v}"
+          echo "TOXENV=$tox_env_name" >> $GITHUB_ENV
+          echo "PYTHON_V=$python_v" >> $GITHUB_ENV
+    - name: "Installing non-python packages"
+      run: |
+         sudo apt-get update -qq
+         DEBIAN_FRONTEND=noninteractive
+         echo "Installing build tools"
+         sudo apt-get install -y build-essential
+         echo "Installing python Pillow library dependencies"
+         sudo apt-get install -y libraqm0 libfreetype6-dev libfribidi-dev libimagequant-dev libjpeg-dev liblcms2-dev libopenjp2-7-dev libtiff5-dev libwebp-dev libxcb1-dev
+    - uses: actions/checkout@v2
+    - name: Set up Python "${{ env.PYTHON_V }}"
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_V }}
+#    - name: Get pip cache dir
+#      id: pip-cache
+#      run: |
+#        echo "::set-output name=dir::$(pip cache dir)"
+#    - name: Cache
+#      uses: actions/cache@v2
+#      with:
+#        path: ${{ steps.pip-cache.outputs.dir }}
+#        key:
+#          -${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}
+#        restore-keys: |
+#          -${{ matrix.python-version }}-v1-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox tox-gh-actions
+    - name: Tox tests
+      run: |
+        tox -e $TOXENV
+    - name: Upload coverage
+      uses: codecov/codecov-action@v1
+      with:
+        name: Python ${{ env.PYTHON_V }}

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ __sized__/*
 # Pickled Files #
 #################
 *.p
+
+.tox
+.idea

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,62 @@
+[tox]
+minversion = 3.23.0
+requires:
+    pip >= 21.0.1
+envlist =
+    flake8
+    py{3.6,3.7}-django{20,22}-drf{307,308,309,310,311}
+    py{3.8,3.9}-django{22}-drf{309,310,311,312}
+    py{3.8,3.9}-django{30,31,32}-drf{311,312}
+
+[gh-actions]
+python =
+    3.6: py3.6
+    3.7: py3.7
+    3.8: py3.8
+    3.9: py3.9
+
+[travis:env]
+DJANGO =
+    2.0: django20
+    2.2: django22
+    3.0: django30
+    3.1: django31
+    3.2: django32
+
+[testenv]
+deps=
+    coverage
+    django18: Django>=1.8.19,<1.9.0
+    django111: Django>=1.11.29,<2.0.0
+    django20: Django>=2.0.13,<2.1.0
+    django21: Django>=2.1.14,<2.2.0
+    django22: Django>=2.2.19,<3.0.0
+    django30: Django>=3.0.13,<3.1.0
+    django31: Django>=3.1.7,<3.2.0
+    django32: Django>=3.2.0rc1,<3.3.0
+    drf304: djangorestframework>=3.4.7,<3.5.0
+    drf305: djangorestframework>=3.5.4,<3.6.0
+    drf306: djangorestframework>=3.6.4,<3.7.0
+    drf307: djangorestframework>=3.7.7,<3.8.0
+    drf308: djangorestframework>=3.8.2,<3.9.0
+    drf309: djangorestframework>=3.9.4,<3.10.0
+    drf310: djangorestframework>=3.10.3,<3.11.0
+    drf311: djangorestframework>=3.11.2,<3.12.0
+    drf312: djangorestframework>=3.12.4,<3.13.0
+    flake8
+sitepackages = False
+recreate = False
+commands =
+    #pip uninstall Pillow -y
+    # force build Pillow from source
+    #pip install --force-reinstall --ignore-installed --no-binary :all: Pillow
+    pip list
+    flake8 versatileimagefield/
+    coverage run --parallel-mode --source=versatileimagefield runtests.py
+    coverage run --parallel-mode --source=versatileimagefield post_processor_runtests.py
+    coverage combine
+
+[testenv:flake8]
+basepython = python3.9
+commands =
+    python -m flake8 {toxinidir}/versatileimagefield {toxinidir}/tests


### PR DESCRIPTION
- Add `tox.ini` configuration to be able to test locally on all supported versions.
- Add support to run tests on Github Actions (Github Actions offers free 2,000 Actions minutes/month per free GitHub account. In paid accounts, this amount may be higher)
- Add `python3.9` to the test matrix. Fix #180
- Add Django 3.1 and Django 3.2rc1 to the test matrix. Fix #182
- Add `djangorestframework` 3.11 and 3.12 to the test matrix. Fix #184

A sample of how the Github Action will look like:
Also, the sample of full  Github Action test log of this PR can be accessed in https://github.com/luzfcb/django-versatileimagefield/actions/runs/692862505


![image](https://user-images.githubusercontent.com/807599/112723057-7ec17b00-8eeb-11eb-9aba-b4f86261d125.png)


