### PR TITLE
Fix caching for dynamic urls

### DIFF
--- a/versatileimagefield/datastructures/filteredimage.py
+++ b/versatileimagefield/datastructures/filteredimage.py
@@ -130,9 +130,9 @@ class FilterLibrary(dict):
 
                     filtered_url = self.storage.url(filtered_path)
                     
-                    static_url = filtered_path
+                    static_url = filtered_url
                     if hasattr(self.storage, 'static_url'):
-                        static_url = self.storage.static_url(resized_storage_path)
+                        static_url = self.storage.static_url(filtered_path)
 
                     filter_cls = self.registry._filter_registry[key]
                     prepped_filter = filter_cls(

--- a/versatileimagefield/datastructures/filteredimage.py
+++ b/versatileimagefield/datastructures/filteredimage.py
@@ -138,7 +138,7 @@ class FilterLibrary(dict):
                         filename_key=key
                     )
                     if self.create_on_demand is True:
-                        if cache.get(filtered_url):
+                        if cache.get(filtered_path):
                             # The filtered_url exists in the cache so the image
                             # already exists. So we `pass` to skip directly to
                             # the return statement.
@@ -153,7 +153,7 @@ class FilterLibrary(dict):
                             # Setting a super-long cache for the newly created
                             # image
                             cache.set(
-                                filtered_url,
+                                filtered_path,
                                 1,
                                 VERSATILEIMAGEFIELD_CACHE_LENGTH
                             )

--- a/versatileimagefield/datastructures/filteredimage.py
+++ b/versatileimagefield/datastructures/filteredimage.py
@@ -128,10 +128,11 @@ class FilterLibrary(dict):
                         storage=self.storage
                     )
 
+                    filtered_url = self.storage.url(filtered_path)
+                    
+                    static_url = filtered_path
                     if hasattr(self.storage, 'static_url'):
-                        filtered_url = self.storage.static_url(filtered_path)
-                    else:
-                        filtered_url = self.storage.url(filtered_path)
+                        static_url = self.storage.static_url(resized_storage_path)
 
                     filter_cls = self.registry._filter_registry[key]
                     prepped_filter = filter_cls(
@@ -141,7 +142,7 @@ class FilterLibrary(dict):
                         filename_key=key
                     )
                     if self.create_on_demand is True:
-                        if cache.get(filtered_url):
+                        if cache.get(static_url):
                             # The filtered_url exists in the cache so the image
                             # already exists. So we `pass` to skip directly to
                             # the return statement.
@@ -156,7 +157,7 @@ class FilterLibrary(dict):
                             # Setting a super-long cache for the newly created
                             # image
                             cache.set(
-                                filtered_url,
+                                static_url,
                                 1,
                                 VERSATILEIMAGEFIELD_CACHE_LENGTH
                             )

--- a/versatileimagefield/datastructures/filteredimage.py
+++ b/versatileimagefield/datastructures/filteredimage.py
@@ -128,7 +128,10 @@ class FilterLibrary(dict):
                         storage=self.storage
                     )
 
-                    filtered_url = self.storage.url(filtered_path)
+                    if hasattr(self.storage, 'static_url'):
+                        filtered_url = self.storage.static_url(filtered_path)
+                    else:
+                        filtered_url = self.storage.url(filtered_path)
 
                     filter_cls = self.registry._filter_registry[key]
                     prepped_filter = filter_cls(
@@ -138,13 +141,13 @@ class FilterLibrary(dict):
                         filename_key=key
                     )
                     if self.create_on_demand is True:
-                        if cache.get(filtered_path):
+                        if cache.get(filtered_url):
                             # The filtered_url exists in the cache so the image
                             # already exists. So we `pass` to skip directly to
                             # the return statement.
                             pass
                         else:
-                            if not self.storage.exists(filtered_path):
+                            if not self.storage.exists(filtered_url):
                                 prepped_filter.create_filtered_image(
                                     path_to_image=self.original_file_location,
                                     save_path_on_storage=filtered_path
@@ -153,7 +156,7 @@ class FilterLibrary(dict):
                             # Setting a super-long cache for the newly created
                             # image
                             cache.set(
-                                filtered_path,
+                                filtered_url,
                                 1,
                                 VERSATILEIMAGEFIELD_CACHE_LENGTH
                             )

--- a/versatileimagefield/datastructures/filteredimage.py
+++ b/versatileimagefield/datastructures/filteredimage.py
@@ -147,7 +147,7 @@ class FilterLibrary(dict):
                             # the return statement.
                             pass
                         else:
-                            if not self.storage.exists(filtered_url):
+                            if not self.storage.exists(filtered_path):
                                 prepped_filter.create_filtered_image(
                                     path_to_image=self.original_file_location,
                                     save_path_on_storage=filtered_path

--- a/versatileimagefield/datastructures/sizedimage.py
+++ b/versatileimagefield/datastructures/sizedimage.py
@@ -124,15 +124,16 @@ class SizedImage(ProcessedImage, dict):
             )
 
             try:
+                resized_url = self.storage.url(resized_storage_path)
+
+                static_url = resized_url
                 if hasattr(self.storage, 'static_url'):
-                    resized_url = self.storage.static_url(resized_storage_path)
-                else:
-                    resized_url = self.storage.url(resized_storage_path)
+                    static_url = self.storage.static_url(resized_storage_path)
             except Exception:
                 resized_url = None
 
             if self.create_on_demand is True:
-                if cache.get(resized_url) and resized_url is not None:
+                if cache.get(static_url) and resized_url is not None:
                     # The sized path exists in the cache so the image already
                     # exists. So we `pass` to skip directly to the return
                     # statement
@@ -150,8 +151,12 @@ class SizedImage(ProcessedImage, dict):
 
                         resized_url = self.storage.url(resized_storage_path)
 
+                        static_url = resized_url
+                        if hasattr(self.storage, 'static_url'):
+                            static_url = self.storage.static_url(resized_storage_path)
+
                     # Setting a super-long cache for a resized image (30 Days)
-                    cache.set(resized_url, 1, VERSATILEIMAGEFIELD_CACHE_LENGTH)
+                    cache.set(static_url, 1, VERSATILEIMAGEFIELD_CACHE_LENGTH)
         return SizedImageInstance(
             name=resized_storage_path,
             url=resized_url,

--- a/versatileimagefield/datastructures/sizedimage.py
+++ b/versatileimagefield/datastructures/sizedimage.py
@@ -124,19 +124,22 @@ class SizedImage(ProcessedImage, dict):
             )
 
             try:
-                resized_url = self.storage.url(resized_storage_path)
+                if hasattr(self.storage, 'static_url'):
+                    resized_url = self.storage.static_url(filtered_path)
+                else:
+                    resized_url = self.storage.url(filtered_path)
             except Exception:
                 resized_url = None
 
             if self.create_on_demand is True:
-                if cache.get(resized_storage_path) and resized_url is not None:
+                if cache.get(resized_url) and resized_url is not None:
                     # The sized path exists in the cache so the image already
                     # exists. So we `pass` to skip directly to the return
                     # statement
                     pass
                 else:
                     if resized_storage_path and not self.storage.exists(
-                        resized_storage_path
+                        resized_url
                     ):
                         self.create_resized_image(
                             path_to_image=self.path_to_image,
@@ -148,7 +151,7 @@ class SizedImage(ProcessedImage, dict):
                         resized_url = self.storage.url(resized_storage_path)
 
                     # Setting a super-long cache for a resized image (30 Days)
-                    cache.set(resized_storage_path, 1, VERSATILEIMAGEFIELD_CACHE_LENGTH)
+                    cache.set(resized_url, 1, VERSATILEIMAGEFIELD_CACHE_LENGTH)
         return SizedImageInstance(
             name=resized_storage_path,
             url=resized_url,

--- a/versatileimagefield/datastructures/sizedimage.py
+++ b/versatileimagefield/datastructures/sizedimage.py
@@ -129,7 +129,7 @@ class SizedImage(ProcessedImage, dict):
                 resized_url = None
 
             if self.create_on_demand is True:
-                if cache.get(resized_url) and resized_url is not None:
+                if cache.get(resized_storage_path) and resized_url is not None:
                     # The sized path exists in the cache so the image already
                     # exists. So we `pass` to skip directly to the return
                     # statement
@@ -148,7 +148,7 @@ class SizedImage(ProcessedImage, dict):
                         resized_url = self.storage.url(resized_storage_path)
 
                     # Setting a super-long cache for a resized image (30 Days)
-                    cache.set(resized_url, 1, VERSATILEIMAGEFIELD_CACHE_LENGTH)
+                    cache.set(resized_storage_path, 1, VERSATILEIMAGEFIELD_CACHE_LENGTH)
         return SizedImageInstance(
             name=resized_storage_path,
             url=resized_url,

--- a/versatileimagefield/datastructures/sizedimage.py
+++ b/versatileimagefield/datastructures/sizedimage.py
@@ -125,9 +125,9 @@ class SizedImage(ProcessedImage, dict):
 
             try:
                 if hasattr(self.storage, 'static_url'):
-                    resized_url = self.storage.static_url(filtered_path)
+                    resized_url = self.storage.static_url(resized_storage_path)
                 else:
-                    resized_url = self.storage.url(filtered_path)
+                    resized_url = self.storage.url(resized_storage_path)
             except Exception:
                 resized_url = None
 
@@ -139,7 +139,7 @@ class SizedImage(ProcessedImage, dict):
                     pass
                 else:
                     if resized_storage_path and not self.storage.exists(
-                        resized_url
+                        resized_storage_path
                     ):
                         self.create_resized_image(
                             path_to_image=self.path_to_image,


### PR DESCRIPTION
If e.g. url is signed with expiry date, the signature
in the url and therefore the cache key that storage
generates will be different every time, rendering
caching useless.