### PR TITLE
Deleted unnecessary default_app_config settings starting with django3.2

### DIFF
--- a/versatileimagefield/__init__.py
+++ b/versatileimagefield/__init__.py
@@ -1,1 +1,5 @@
-default_app_config = 'versatileimagefield.apps.VersatileImageFieldConfig'
+import django
+
+
+if django.VERSION < (3, 2):
+    default_app_config = 'versatileimagefield.apps.VersatileImageFieldConfig'


### PR DESCRIPTION
**Warning problem solving**
python3.9/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'versatileimagefield' defines default_app_config = 'versatileimagefield.apps.VersatileImageFieldConfig'. Django now detects this configuration automatically. You can remove default_app_config.