### PR TITLE
fix: use `Image.Resampling.LANCZOS` instead of `Image.ANTIALIAS` when available

### DIFF
--- a/docs/writing_custom_sizers_and_filters.rst
+++ b/docs/writing_custom_sizers_and_filters.rst
@@ -77,7 +77,7 @@ For an example, let's take a look at the ``thumbnail`` Sizer (``versatileimagefi
             imagefile = BytesIO()
             image.thumbnail(
                 (width, height),
-                Image.ANTIALIAS
+                Image.Resampling.LANCZOS
             )
             image.save(
                 imagefile,
@@ -311,7 +311,7 @@ is registered (see the highlighted lines in the following code block for the rel
             imagefile = BytesIO()
             image.thumbnail(
                 (width, height),
-                Image.ANTIALIAS
+                Image.Resampling.LANCZOS
             )
             image.save(
                 imagefile,

--- a/versatileimagefield/versatileimagefield.py
+++ b/versatileimagefield/versatileimagefield.py
@@ -7,6 +7,12 @@ from .datastructures import FilteredImage, SizedImage
 from .registry import versatileimagefield_registry
 
 
+try:
+    ANTIALIAS = Image.Resampling.LANCZOS
+except AttributeError:
+    ANTIALIAS = Image.ANTIALIAS  # deprecated in 9.1.0 and removed in 10.0.0
+
+
 class CroppedImage(SizedImage):
     """
     A SizedImage subclass that creates a 'cropped' image.
@@ -115,7 +121,7 @@ class CroppedImage(SizedImage):
         # (as determined by `width`x`height`)
         return cropped_image.resize(
             (width, height),
-            Image.ANTIALIAS
+            ANTIALIAS
         )
 
     def process_image(self, image, image_format, save_kwargs,
@@ -168,7 +174,7 @@ class ThumbnailImage(SizedImage):
         imagefile = BytesIO()
         image.thumbnail(
             (width, height),
-            Image.ANTIALIAS
+            ANTIALIAS
         )
         image.save(
             imagefile,


### PR DESCRIPTION
`Image.ANTIALIAS` was deprecated in 9.1.0 and removed in 10.0.0 in favor of `Image.Resampling.LANCZOS` see https://pillow.readthedocs.io/en/stable/deprecations.html#constants Note 10.0.0 was released on 1 July https://pypi.org/project/Pillow/10.0.0/