### PR TITLE
Test updates

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -1,11 +1,5 @@
-Django==2.2.8
-Pillow>=6.2.0
-Sphinx==1.2.3
-coverage==5.5
-coveralls==3.0.1
-djangorestframework==3.10.3
-flake8==2.2.5
-python-magic==0.4.22
-requests==2.5.1
-sphinx-rtd-theme==0.1.6
-testfixtures==6.17.1
+Pillow
+coverage
+coveralls
+djangorestframework
+testfixtures

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ DJANGO =
     5.0: django50
 
 [testenv]
-passenv = TRAVIS TRAVIS_* GITHUB_*
+passenv = TRAVIS,TRAVIS_*,GITHUB_*
 deps=
     coverage
     coveralls


### PR DESCRIPTION
Following #207 , I started playing with the project and getting tests running:
- Updates tox file so that it works with version 4
https://tox.wiki/en/4.0.3/faq.html#tox-4-changed-ini-rules
- Updates `test_reqs.txt` to be consistent with tox.ini (versions and packages in test_reqs.txt were outdated)
- Adds django `manage.py` file pointing to test `tests.test_settings` config file.

First 2 were breaking my test runs.
3rd one allows running tests simply by running `python manage.py test` in console - so "django way" of running tests. That means I can run every single test method by simply clicking icon in PyCharm, yay!

I haven't dived deeper into `runtests.py` and `post_processor_runtests`, but from first glance it seems like these could be fully removed - 1st by just doing `python manage.py test` and the second by running it with `--testrunner tests.post_processor.discover_tests.DiscoverPostProcessorRunner`.